### PR TITLE
fix usage of deprecated gradle feature in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Maven:
 Gradle:
 
 ```groovy
-compile 'com.github.jhg023:SimpleNet:1.4.2'
+implementation 'com.github.jhg023:SimpleNet:1.4.2'
 ```
 
  2. Because SimpleNet is compiled with Java 11, you must first require its module in your `module-info.java`:


### PR DESCRIPTION
`compile` is deprecated, `implementation` is the thing to go now